### PR TITLE
fix: explicit load of external dtd

### DIFF
--- a/t/01_libxml.t
+++ b/t/01_libxml.t
@@ -32,7 +32,7 @@ my $xhtml = <<'__EOI__';
 </html>
 __EOI__
 
-my $parser = XML::LibXML->new();
+my $parser = XML::LibXML->new(load_ext_dtd => 1);
 $parser->no_network(1);
 
 my $doc;


### PR DESCRIPTION
change in api for XML::LibXML now requires explicit loading of external DTD
https://metacpan.org/release/SHLOMIF/XML-LibXML-2.0202/source/Changes#L4-5

bug reports: 
- https://rt.cpan.org/Ticket/Display.html?id=131488
- https://rt.cpan.org/Ticket/Display.html?id=150351
